### PR TITLE
KM-14522: Fix false dead-tunnel kills and improve liveness detection reliability

### DIFF
--- a/Sources/PIAWireguard/AppExtension/WGPacketTunnelProvider+Connectivity.swift
+++ b/Sources/PIAWireguard/AppExtension/WGPacketTunnelProvider+Connectivity.swift
@@ -64,17 +64,25 @@ extension WGPacketTunnelProvider {
     private func checkNetworkActivity() {
         let currentRxBytes = self.latestWireGuardSettings.rx_bytes
 
-        self.updateSettings()
+        guard self.updateSettings() else {
+            wg_log(.info, message: "Settings fetch failed, skipping connectivity check")
+            return
+        }
 
         let bytesUpdated = currentRxBytes != self.latestWireGuardSettings.rx_bytes
-        // Checked on every tick: a recent handshake confirms the peer is reachable at the
-        // protocol level even when no application traffic flows (idle connection). Many servers
-        // also block ICMP, so pings may never produce RX bytes — the handshake timestamp is a
-        // stronger liveness signal than byte counts alone.
-        let handshakeRecent = self.latestWireGuardSettings.isHandshakeCompleted()
 
-        if bytesUpdated || handshakeRecent {
-            wg_log(.info, message: "Tunnel alive (bytesUpdated=\(bytesUpdated), handshakeRecent=\(handshakeRecent)). Resetting counter")
+        let currentHandshakeDate = self.latestWireGuardSettings.last_handshake_time_sec
+        // A new successful handshake since the last tick is an immediate liveness confirmation.
+        let handshakeAdvanced = currentHandshakeDate > lastSeenHandshakeDate
+        lastSeenHandshakeDate = currentHandshakeDate
+        // WireGuard re-keys every ~120 s (REKEY_AFTER_TIME). Between re-keyings on an idle
+        // connection the server may not reply to keepalives, so neither bytes nor a new
+        // handshake appear — but the tunnel is alive. Allow the full re-keying cycle before
+        // starting the kill counter.
+        let handshakeRecent = currentHandshakeDate > Date().addingTimeInterval(-120)
+
+        if bytesUpdated || handshakeAdvanced || handshakeRecent {
+            wg_log(.info, message: "Tunnel alive (bytesUpdated=\(bytesUpdated), handshakeAdvanced=\(handshakeAdvanced), handshakeRecent=\(handshakeRecent)). Resetting counter")
             wireGuardConnectionAttempts = 0
             pinger?.stop()
         } else {

--- a/Sources/PIAWireguard/AppExtension/WGPacketTunnelProvider.swift
+++ b/Sources/PIAWireguard/AppExtension/WGPacketTunnelProvider.swift
@@ -23,10 +23,11 @@ open class WGPacketTunnelProvider: NEPacketTunnelProvider {
     var pinger: SwiftyPing!
     var connectivityTimer: Timer?
     var latestWireGuardSettings: WGSettingsResponse!
-    let wireGuardMaxConnectionAttempts = 3
+    let wireGuardMaxConnectionAttempts = 6
     let connectivityInterval: TimeInterval = 10
     let pingInterval: TimeInterval = 2
     var wireGuardConnectionAttempts = 0
+    var lastSeenHandshakeDate: Date = .distantPast
     
     var providerConfiguration: [String: Any]!
 
@@ -195,21 +196,22 @@ open class WGPacketTunnelProvider: NEPacketTunnelProvider {
 
     }
     
-    func updateSettings(completionHandler: ((Data?) -> Void)? = nil) {
-        
+    @discardableResult
+    func updateSettings(completionHandler: ((Data?) -> Void)? = nil) -> Bool {
+
         guard let handle = handle else {
             completionHandler?(nil)
-            return
-            
+            return false
         }
 
         guard let settings = wgGetConfig(handle) else {
             completionHandler?(nil)
-            return
+            return false
         }
 
         latestWireGuardSettings = WGSettingsResponse(withSettings: String(cString: settings))
         free(settings)
+        return true
     }
     
 }

--- a/Sources/PIAWireguard/AppExtension/Wireguard/WGSettingsResponse.swift
+++ b/Sources/PIAWireguard/AppExtension/Wireguard/WGSettingsResponse.swift
@@ -46,7 +46,7 @@ class WGSettingsResponse {
         if handshakeTime != "", handshakeTime != "0", let time = Double(handshakeTime), time != 0.0 {
             return Date(timeIntervalSince1970: time)
         } else {
-            return Date()
+            return Date.distantPast
         }
     }
     var last_handshake_time_nsec: String {
@@ -83,27 +83,6 @@ class WGSettingsResponse {
             }
         }
 
-    }
-    
-}
-
-extension WGSettingsResponse {
-    
-    func isHandshakeCompleted() -> Bool {
-    
-        let lastHandshake = self.last_handshake_time_sec
-        //2 minutes without handshake
-        let nextHandshake = lastHandshake.addingTimeInterval(150)
-        
-        wg_log(.info, message: "Last handshake \(lastHandshake)")
-        
-        //the last handshake was more than 2 minutes ago
-        if nextHandshake > Date() {
-            return true
-        }
-                
-        return false
-        
     }
     
 }


### PR DESCRIPTION
## Summary

- **`WGSettingsResponse`**: `last_handshake_time_sec` returned `Date()` (now) when the WireGuard value was `0`/missing, making the handshake check permanently return *alive* and never detect dead tunnels. Fixed to return `Date.distantPast`.
- **`updateSettings()`**: silently swallowed `wgGetConfig` failures, leaving stale settings in place. The connectivity check would compare identical values, count the tick as dead, and eventually kill a healthy tunnel. Now returns `Bool`; failed fetches skip the tick entirely.
- **Kill threshold**: `wireGuardMaxConnectionAttempts` raised from 3 → 6 (30 s → 60 s) to accommodate 25 s keepalive timing and iOS background timer jitter.
- **Liveness signals**: replaced the single `isHandshakeCompleted()` time-window check with three complementary signals — `bytesUpdated`, `handshakeAdvanced` (timestamp moved forward since last tick), and `handshakeRecent` (within WireGuard's 120 s REKEY_AFTER_TIME). This correctly handles active traffic, new handshakes, and the normal idle gap between re-keyings without false-killing stable connections.