### PR TITLE
KM-14792: Update mobile-ios-networking to 1.3.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git", exact: "1.1.0"),
-        .package(url: "git@github.com:pia-foss/mobile-ios-networking.git", exact: "1.3.1"),
+        .package(url: "git@github.com:pia-foss/mobile-ios-networking.git", exact: "1.3.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- Bumps `mobile-ios-networking` dependency from `1.3.1` to `1.3.2`